### PR TITLE
Update EditCustomerForm.cs

### DIFF
--- a/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
+++ b/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
@@ -84,7 +84,7 @@ namespace HobbyManiaManager.Forms
 
         private void CreateCustomerLoad()
         {
-            textBoxId.Text = Customer.NextCustomerId.ToString();
+            textBoxId.Text = (_customersRepository.GetAll().Last().Id + 1).ToString();
             dateTimePickerRegDate.Value = DateTime.Now;
             Text = "Create New Customer";
 

--- a/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
+++ b/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
@@ -84,7 +84,9 @@ namespace HobbyManiaManager.Forms
 
         private void CreateCustomerLoad()
         {
-            textBoxId.Text = (_customersRepository.GetAll().Last().Id + 1).ToString();
+            textBoxId.Text = "0";
+            textBoxId.Visible = false;
+            labelId.Visible = false;
             dateTimePickerRegDate.Value = DateTime.Now;
             Text = "Create New Customer";
 
@@ -113,6 +115,7 @@ namespace HobbyManiaManager.Forms
         private void CreateCustomer()
         {
             var newCustomer = GetFormCustomer();
+            newCustomer.Id = Customer.NextCustomerId;
             _customersRepository.Add(newCustomer);
             buttonUpdateCreate.Text = "Update";
         }

--- a/HobbyManiaManager/Forms/Rental/RentalHistoryForm.cs
+++ b/HobbyManiaManager/Forms/Rental/RentalHistoryForm.cs
@@ -40,5 +40,10 @@ namespace HobbyManiaManager.Forms
             }
             return new RentalDataGridViewModel(m, r);
         }
+
+        private void buttonClose_Click(object sender, EventArgs e)
+        {
+            Dispose();
+        }
     }
 }


### PR DESCRIPTION
The current version of the form calls the NextCustomerId method inside CreateCustomerLoad(). This causes that every time you click the "Create User" button, even if you don’t actually create a new user and just close the EditCustomerForm, a new customer ID is generated and never used.

To avoid this and prevent "lost" IDs, it's better to generate the new ID from the last item in the list using .Last(). This way, the new ID is always based on the latest existing one.

Changes made:

- Updated the CreateCustomerLoad() method in EditCustomerForm.cs.

P.S.: The RentalHistoryForm.cs had a "Close" button with no functionality. It's necessary to implement Dispose().