### PR TITLE
Version 3

### DIFF
--- a/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
+++ b/HobbyManiaManager/Forms/Customer/EditCustomerForm.cs
@@ -36,6 +36,7 @@ namespace HobbyManiaManager.Forms
             if (_customer == null)
             {
                 CreateCustomerLoad();
+                buttonRentalHistory.Enabled = false; //Disable the rent button when creating a user
             }
             else
             {

--- a/HobbyManiaManager/Forms/Customer/ListCustomersForm.cs
+++ b/HobbyManiaManager/Forms/Customer/ListCustomersForm.cs
@@ -45,6 +45,7 @@ namespace HobbyManiaManager.Forms
 
         private void buttonSearch_Click(object sender, EventArgs e)
         {
+            if (string.IsNullOrWhiteSpace(textBoxId.Text)) return; //if it is empty or has spaces, do nothing
             dataGridViewCustomersList.DataSource = _repository.GetAll().Where(c => c.Id.ToString() == textBoxId.Text).ToList();
             dataGridViewCustomersList.Refresh();
         }


### PR DESCRIPTION
I have disabled the "View User Rent" button during the user creation process, as it was causing the application to crash. Additionally, I implemented a minor improvement to the "Search by ID" button: it is now disabled when the input field is empty, preventing the user list from being unintentionally cleared.